### PR TITLE
Add handling of QR Code PK as a 3rd row of the paper wallet output

### DIFF
--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/Application.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/Application.java
@@ -166,7 +166,7 @@ public class Application {
 
 		String html = WalletPageUtility.createHtml(pw);
 		byte [] qrCode = QrCodeUtility.contentToPngBytes(pw.getAddress(), 256);
-		byte [] qrCodePK = QrCodeUtility.contentToPngBytes(pw.getPrivateKey().toString(), 128);
+		byte [] qrCodePK = QrCodeUtility.contentToPngBytes(pw.getPrivateKey(), 128);
 
 		String path = pw.getPathToFile();
 		String baseName = pw.getBaseName();

--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/Application.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/Application.java
@@ -166,18 +166,20 @@ public class Application {
 
 		String html = WalletPageUtility.createHtml(pw);
 		byte [] qrCode = QrCodeUtility.contentToPngBytes(pw.getAddress(), 256);
+		byte [] qrCodePK = QrCodeUtility.contentToPngBytes(pw.getPrivateKey().toString(), 128);
 
 		String path = pw.getPathToFile();
 		String baseName = pw.getBaseName();
 		String htmlFile = String.format("%s%s%s.%s", path, File.separator, baseName, EXT_HTML);
 		String pngFile = String.format("%s%s%s.%s", path, File.separator, baseName, EXT_PNG);
-
+		String pngFilePK = String.format("%s%s%s.%s", path, File.separator, baseName+"PK", EXT_PNG);
 		log("writing additional output files ...");
 		FileUtility.saveToFile(html, htmlFile);
 		FileUtility.saveToFile(qrCode, pngFile);
+		FileUtility.saveToFile(qrCodePK, pngFile);
 		log(String.format("html wallet: %s", htmlFile));
 		log(String.format("address qr code: %s", pngFile));
-		
+		log(String.format("address qr code of PK: %s", pngFilePK));
 		return String.format("%s %s", CREATE_OK, pw.getFile().getAbsolutePath());
 	}
 

--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/PaperWallet.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/PaperWallet.java
@@ -149,7 +149,7 @@ public class PaperWallet {
 		return passPhrase;
 	}
 
-	public java.math.BigInteger getPrivateKey() {
+	public String getPrivateKey() {
 		return Numeric.toHexStringWithPrefix(credentials.getEcKeyPair().getPrivateKey());
 	}
 

--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/PaperWallet.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/PaperWallet.java
@@ -150,7 +150,7 @@ public class PaperWallet {
 	}
 
 	public java.math.BigInteger getPrivateKey() {
-		return credentials.getEcKeyPair().getPrivateKey();
+		return Numeric.toHexStringWithPrefix(credentials.getEcKeyPair().getPrivateKey());
 	}
 
 	public String getPathToFile() {

--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/PaperWallet.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/PaperWallet.java
@@ -149,6 +149,10 @@ public class PaperWallet {
 		return passPhrase;
 	}
 
+	public java.math.BigInteger getPrivateKey() {
+		return credentials.getEcKeyPair().getPrivateKey();
+	}
+
 	public String getPathToFile() {
 		return pathToFile;
 	}

--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/WalletPageUtility.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/WalletPageUtility.java
@@ -124,7 +124,7 @@ public class WalletPageUtility extends HtmlUtility {
 
 		// qr code for privatekey
 		HtmlUtility.addOpenDiv(html, CSS_COLUMN);
-		byte [] walletPKQrCode = QrCodeUtility.contentToPngBytes(wallet.getPrivateKey().toString(), 128);
+		byte [] walletPKQrCode = QrCodeUtility.contentToPngBytes(wallet.getPrivateKey(), 128);
 		HtmlUtility.addEncodedImage(html, walletPKQrCode, 128, CSS_IMG_WALLET);
 		HtmlUtility.addParagraph(html, "QR Code PK", CSS_CAPTION);
 		HtmlUtility.addCloseDiv(html);

--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/WalletPageUtility.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/WalletPageUtility.java
@@ -119,6 +119,25 @@ public class WalletPageUtility extends HtmlUtility {
 		HtmlUtility.addCloseDiv(html);		
 		HtmlUtility.addCloseDiv(html);		
 		
+		// add 3rd row
+		HtmlUtility.addOpenDiv(html, CSS_CLEARFIX);
+
+		// qr code for privatekey
+		HtmlUtility.addOpenDiv(html, CSS_COLUMN);
+		byte [] walletPKQrCode = QrCodeUtility.contentToPngBytes(wallet.getPrivateKey().toString(), 128);
+		HtmlUtility.addEncodedImage(html, walletPKQrCode, 128, CSS_IMG_WALLET);
+		HtmlUtility.addParagraph(html, "QR Code PK", CSS_CAPTION);
+		HtmlUtility.addCloseDiv(html);
+		
+		// address, pass phrase, wallet file, file name
+		HtmlUtility.addOpenDiv(html, CSS_FILL);
+		HtmlUtility.addOpenDiv(html, CSS_CONTENT);
+		HtmlUtility.addContent(html, wallet.getPrivateKey().toString());
+		HtmlUtility.addCloseDiv(html);
+		HtmlUtility.addParagraph(html, "PK", CSS_CAPTION);
+		
+		HtmlUtility.addCloseDiv(html);		
+		HtmlUtility.addCloseDiv(html);
 		// add footer content
 		String footer = String.format("Page created with EPW Generator [%s] V %s", REPOSITORY, VERSION);
 		HtmlUtility.addOpenFooter(html, CSS_FOOTER);

--- a/src/main/java/org/matthiaszimmermann/ethereum/pwg/WalletPageUtility.java
+++ b/src/main/java/org/matthiaszimmermann/ethereum/pwg/WalletPageUtility.java
@@ -129,15 +129,6 @@ public class WalletPageUtility extends HtmlUtility {
 		HtmlUtility.addParagraph(html, "QR Code PK", CSS_CAPTION);
 		HtmlUtility.addCloseDiv(html);
 		
-		// address, pass phrase, wallet file, file name
-		HtmlUtility.addOpenDiv(html, CSS_FILL);
-		HtmlUtility.addOpenDiv(html, CSS_CONTENT);
-		HtmlUtility.addContent(html, wallet.getPrivateKey().toString());
-		HtmlUtility.addCloseDiv(html);
-		HtmlUtility.addParagraph(html, "PK", CSS_CAPTION);
-		
-		HtmlUtility.addCloseDiv(html);		
-		HtmlUtility.addCloseDiv(html);
 		// add footer content
 		String footer = String.format("Page created with EPW Generator [%s] V %s", REPOSITORY, VERSION);
 		HtmlUtility.addOpenFooter(html, CSS_FOOTER);


### PR DESCRIPTION
This is related to #2 , conceptually we were thinking to add PK as another output from the QR codes for the paper wallet.  I tested and it *does work* as a QR code in the third row, however it *does not work* with JAXX.  Maybe JAXX has other issues, as I see other people complaining about it's less than stellar import capabilities.  Is this PK encrypted?

You are free to decide if this is a good addition or not.  I will separately explore what other wallet, maybe an electrum based one, will be functional.